### PR TITLE
Add an application dependency on :ssl

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -8,7 +8,7 @@ defmodule HTTPotion.Mixfile do
   end
 
   def application do
-    [applications: [:ibrowse]]
+    [applications: [:ibrowse, :ssl]]
   end
 
   defp deps do


### PR DESCRIPTION
I'm not sure if you'll agree with this, but is you use an https url in HTTPotion, it relies on SSL. Without the dependency, this then fails.

Of course, folks could also just add the dependency in their own apps, but that seems a little indirect.

Your call whether you accept this.

Dave
