### PR TITLE
Fix #7 and process URL as binary

### DIFF
--- a/lib/httpotion.ex
+++ b/lib/httpotion.ex
@@ -7,8 +7,10 @@ defmodule HTTPotion.Base do
       end
 
       def process_url(url) do
-        if :string.substr(url, 1, 4) != 'http' do
-          :string.concat 'http://', url
+        url = to_binary(url)
+
+        unless url =~ %r/\Ahttps?:\/\// do
+          "http://" <> url
         else
           url
         end
@@ -68,7 +70,7 @@ defmodule HTTPotion.Base do
       Raises  HTTPotion.HTTPError if failed.
       """
       def request(method, url, body // "", headers // [], options // []) do
-        url = process_url to_char_list(url)
+        url = to_char_list process_url(url)
         timeout = Keyword.get options, :timeout, 5000
         stream_to = Keyword.get options, :stream_to
         ib_options = []

--- a/test/httpotion_test.exs
+++ b/test/httpotion_test.exs
@@ -5,44 +5,52 @@ defmodule HTTPotionTest do
   import ExUnit.CaptureIO
 
   test "get" do
-    assert_response HTTPotion.get("http://httpbin.org/get")
+    assert_response HTTPotion.get("httpbin.org/get")
   end
 
   test "head" do
-    assert_response HTTPotion.head("http://httpbin.org/get"), fn(response) ->
+    assert_response HTTPotion.head("httpbin.org/get"), fn(response) ->
       assert response.body == ""
     end
   end
 
   test "post" do
-    assert_response HTTPotion.post("http://httpbin.org/post", "test")
+    assert_response HTTPotion.post("httpbin.org/post", "test")
   end
 
   test "put" do
-    assert_response HTTPotion.put("http://httpbin.org/put", "test")
+    assert_response HTTPotion.put("httpbin.org/put", "test")
   end
 
   test "patch" do
-    assert_response HTTPotion.patch("http://httpbin.org/patch", "test")
+    assert_response HTTPotion.patch("httpbin.org/patch", "test")
   end
 
   test "delete" do
-    assert_response HTTPotion.delete("http://httpbin.org/delete")
+    assert_response HTTPotion.delete("httpbin.org/delete")
   end
 
   test "options" do
-    assert_response HTTPotion.options("http://httpbin.org/get"), fn(response) ->
+    assert_response HTTPotion.options("httpbin.org/get"), fn(response) ->
       assert response.headers[:Allow] == "HEAD, OPTIONS, GET"
     end
+  end
+
+  test "explicit http scheme" do
+    assert_response HTTPotion.head("http://httpbin.org/get")
   end
 
   test "https scheme" do
     assert_response HTTPotion.head("https://httpbin.org/get")
   end
 
+  test "char list URL" do
+    assert_response HTTPotion.head('httpbin.org/get')
+  end
+
   test "exception" do
     assert_raise HTTPotion.HTTPError, "econnrefused", fn ->
-      HTTPotion.get "http://localhost:1"
+      HTTPotion.get "localhost:1"
     end
   end
 
@@ -57,11 +65,11 @@ defmodule HTTPotionTest do
       end
     end
 
-    assert capture_io(fn -> TestClient.head("http://httpbin.org/get") end) == "ok"
+    assert capture_io(fn -> TestClient.head("httpbin.org/get") end) == "ok"
   end
 
   test "asynchronous request" do
-    HTTPotion.AsyncResponse[id: id] = HTTPotion.get "http://httpbin.org/get", [], [stream_to: self]
+    HTTPotion.AsyncResponse[id: id] = HTTPotion.get "httpbin.org/get", [], [stream_to: self]
 
     assert_receive HTTPotion.AsyncHeaders[id: ^id, status_code: 200, headers: _headers], 1_000
     assert_receive HTTPotion.AsyncChunk[id: ^id, chunk: _chunk], 1_000


### PR DESCRIPTION
The version of application should be bumped to 0.2.0 because of `process_url` change. It could brake overrided `process_url` method in the existing applications.
