### PR TITLE
Updated README example of API client

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ You can also extend it to make cool API clients or something (this example uses 
 defmodule GitHub do
   use HTTPotion.Base
   def process_url(url) do
-    "https://api.github.com" <> url
+    "https://api.github.com/" <> url
   end
   def process_response_body(body) do
     json = :jsx.decode to_string(body)
@@ -32,7 +32,7 @@ defmodule GitHub do
 end
 
 iex> GitHub.start
-iex> GitHub.get("users/myfreeweb").body[:public_repos]
+iex> GitHub.get("users/myfreeweb", ["User-Agent": "httpotion-example"]).body[:public_repos]
 37
 ```
 


### PR DESCRIPTION
A naïve copy and paste of the example API client doesn't work, because `process_url` will create a URL without a slash between `github.com` and `users/myfreeweb`. 

Secondly, the GitHub API will refuse requests that do not have a User-Agent[1](http://developer.github.com/v3/#user-agent-required). I see that this project has a `process_headers` override, but only for response headers. Being able to do this for request headers too would be helpful. I'm not knowledgeable enough yet to make this change cleanly. :)
