### PR TITLE
fix 204 codes parsing

### DIFF
--- a/lib/httpotion.ex
+++ b/lib/httpotion.ex
@@ -81,6 +81,12 @@ defmodule HTTPotion.Base do
         headers = Enum.map process_request_headers(headers), fn ({k, v}) -> { to_char_list(k), to_char_list(v) } end
         body = process_request_body body
         case :ibrowse.send_req(url, headers, method, body, ib_options, timeout) do
+          {:ok, status_code, headers, body, _} ->
+            HTTPotion.Response[
+              status_code: process_status_code(status_code),
+              headers: process_response_headers(headers),
+              body: process_response_body(body)
+            ]
           {:ok, status_code, headers, body} ->
             HTTPotion.Response[
               status_code: process_status_code(status_code),


### PR DESCRIPTION
Sometimes when say riak returns 204 code ibrowse returns response in tuple of different size holding request body itself, like this:

``` erlang
{:ok, '204', 
    [{'Vary', 'Accept-Encoding'}, 
     {'Server', 'MochiWeb/1.1 WebMachine/1.9.2 (someone had painted it blue)'}, 
     {'Date', 'Mon, 17 Mar 2014 10:32:53 GMT'}, 
     {'Content-Type', 'application/json'}, 
     {'Content-Length', '0'}
    ], 
    [], 
    "DELETE /riak/testbucket/ek0qjcmndjosushea0gh19olp6 HTTP/1.1\r\nHost: 127.0.0.1:8098\r\nContent-Length: 0\r\n\r\n"
```
