### PR TITLE
Updates for elixir v0.13.2

### DIFF
--- a/lib/httpotion.ex
+++ b/lib/httpotion.ex
@@ -18,11 +18,11 @@ defmodule HTTPotion.Base do
       def process_request_headers(headers), do: headers
 
       def process_response_body(body) do
-        iolist_to_binary body
+        iodata_to_binary body
       end
 
       def process_response_chunk(chunk) do
-        iolist_to_binary chunk
+        iodata_to_binary chunk
       end
 
       def process_response_headers(headers) do

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule HTTPotion.Mixfile do
   def project do
     [app: :httpotion,
      version: "0.2.3",
-     elixir:  "~> 0.13.0",
+     elixir:  "~> 0.13.1",
      deps: deps]
   end
 


### PR DESCRIPTION
Elixir version is adjusted too, as iodata_to_binary is available at v0.13.1.
