### PR TITLE
fix Readme according to Elixir 0.13.x changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ defmodule GitHub do
   end
 
   def process_request_headers(headers) do
-    Dict.put headers, "User-Agent", "github-potion"
+    Dict.put headers, :"User-Agent", "github-potion"
   end
 
   def process_response_body(body) do


### PR DESCRIPTION
Keyword keys must be atoms since 0.13. The http headers are Keyword list underneath.
