### PR TITLE
Fix crash when using ibrowse option save_response_to_file

### DIFF
--- a/lib/httpotion.ex
+++ b/lib/httpotion.ex
@@ -18,7 +18,7 @@ defmodule HTTPotion.Base do
       def process_request_headers(headers), do: headers
 
       def process_response_body(body = {:file, filename}) do
-        {:file, IO.iodata_to_binary(filename)}
+        IO.iodata_to_binary(filename)
       end
 
       def process_response_body(body) do

--- a/lib/httpotion.ex
+++ b/lib/httpotion.ex
@@ -17,6 +17,10 @@ defmodule HTTPotion.Base do
 
       def process_request_headers(headers), do: headers
 
+      def process_response_body(body = {:file, filename}) do
+        {:file, IO.iodata_to_binary(filename)}
+      end
+
       def process_response_body(body) do
         IO.iodata_to_binary body
       end

--- a/test/httpotion_test.exs
+++ b/test/httpotion_test.exs
@@ -54,6 +54,12 @@ defmodule HTTPotionTest do
     assert_response HTTPotion.get("http://httpbin.org/basic-auth/foo/bar", [], [ ibrowse: ibrowse ])
   end
 
+  test "ibrowse save_response_to_file" do
+    file = Path.join(System.tmp_dir, "httpotion_ibrowse_test.txt")
+    ibrowse = [save_response_to_file: String.to_char_list(file)]
+    assert_response HTTPotion.get("http://httpbin.org/bytes/2048", [], [ibrowse: ibrowse])
+  end
+
   test "explicit http scheme" do
     assert_response HTTPotion.head("http://httpbin.org/get")
   end


### PR DESCRIPTION
Sending a request with the ibrowse option `:save_response_to_file` enabled resulted in a response with a tuple body instead of iodata. `process_response_body/1` then tried to stuff this tuple into `IO.iodata_to_binary`, which crashed with an argument error.