### PR TITLE
wrap send_req_direct

### DIFF
--- a/lib/httpotion.ex
+++ b/lib/httpotion.ex
@@ -102,10 +102,14 @@ defmodule HTTPotion.Base do
       Raises  HTTPotion.HTTPError if failed.
       """
       def request(method, url, body \\ "", headers \\ [], options \\ []) do
-        args = process_arguments(method, url, body, headers, options)
+        if conn_pid = Keyword.get(options, :direct) do
+          request_direct(conn_pid, method, url, body, headers, options)
+        else
+          args = process_arguments(method, url, body, headers, options)
 
-        :ibrowse.send_req(args[:url], args[:headers], args[:method], args[:body], args[:ib_options], args[:timeout])
-        |> handle_response
+          :ibrowse.send_req(args[:url], args[:headers], args[:method], args[:body], args[:ib_options], args[:timeout])
+          |> handle_response
+        end
       end
 
       def request_direct(conn_pid, method, url, body \\ "", headers \\ [], options \\ []) do
@@ -147,14 +151,6 @@ defmodule HTTPotion.Base do
       def patch(url, body, headers \\ [], options \\ []), do: request(:patch, url, body, headers, options)
       def delete(url, headers \\ [], options \\ []),      do: request(:delete, url, "", headers, options)
       def options(url, headers \\ [], options \\ []),     do: request(:options, url, "", headers, options)
-
-      def get_direct(conn_pid, url, headers \\ [], options \\ []),         do: request_direct(conn_pid, :get, url, "", headers, options)
-      def put_direct(conn_pid, url, body, headers \\ [], options \\ []),   do: request_direct(conn_pid, :put, url, body, headers, options)
-      def head_direct(conn_pid, url, headers \\ [], options \\ []),        do: request_direct(conn_pid, :head, url, "", headers, options)
-      def post_direct(conn_pid, url, body, headers \\ [], options \\ []),  do: request_direct(conn_pid, :post, url, body, headers, options)
-      def patch_direct(conn_pid, url, body, headers \\ [], options \\ []), do: request_direct(conn_pid, :patch, url, body, headers, options)
-      def delete_direct(conn_pid, url, headers \\ [], options \\ []),      do: request_direct(conn_pid, :delete, url, "", headers, options)
-      def options_direct(conn_pid, url, headers \\ [], options \\ []),     do: request_direct(conn_pid, :options, url, "", headers, options)
 
       defoverridable Module.definitions_in(__MODULE__)
     end

--- a/test/direct_test.exs
+++ b/test/direct_test.exs
@@ -9,72 +9,72 @@ defmodule DirectTest do
   end
 
   test "get" do
-    assert_response HTTPotion.get_direct(:non_pooled_connection, "httpbin.org"), fn(response) ->
+    assert_response HTTPotion.get("httpbin.org", [direct: :non_pooled_connection]), fn(response) ->
       assert match?(<<60, 33, 68, 79, _ :: binary>>, response.body)
     end
   end
 
   test "head" do
-    assert_response HTTPotion.head_direct(:non_pooled_connection, "httpbin.org/get"), fn(response) ->
+    assert_response HTTPotion.head("httpbin.org/get", [direct: :non_pooled_connection]), fn(response) ->
       assert response.body == ""
     end
   end
 
   test "post charlist body" do
-    assert_response HTTPotion.post_direct(:non_pooled_connection, "httpbin.org/post", 'test')
+    assert_response HTTPotion.post("httpbin.org/post", 'test', [direct: :non_pooled_connection])
   end
 
   test "post binary body" do
     { :ok, file } = File.read(fixture_path("image.png"))
 
-    assert_response HTTPotion.post_direct(:non_pooled_connection, "httpbin.org/post", file)
+    assert_response HTTPotion.post("httpbin.org/post", file, [direct: :non_pooled_connection])
   end
 
   test "put" do
-    assert_response HTTPotion.put_direct(:non_pooled_connection, "httpbin.org/put", "test")
+    assert_response HTTPotion.put("httpbin.org/put", "test", [direct: :non_pooled_connection])
   end
 
   test "patch" do
-    assert_response HTTPotion.patch_direct(:non_pooled_connection, "httpbin.org/patch", "test")
+    assert_response HTTPotion.patch("httpbin.org/patch", "test", [direct: :non_pooled_connection])
   end
 
   test "delete" do
-    assert_response HTTPotion.delete_direct(:non_pooled_connection, "httpbin.org/delete")
+    assert_response HTTPotion.delete("httpbin.org/delete", [direct: :non_pooled_connection])
   end
 
   test "options" do
-    assert_response HTTPotion.options_direct(:non_pooled_connection, "httpbin.org/get"), fn(response) ->
+    assert_response HTTPotion.options("httpbin.org/get", [direct: :non_pooled_connection]), fn(response) ->
       assert response.headers[:"Content-Length"] == "0"
       assert is_binary(response.headers[:Allow])
     end
   end
 
   test "headers" do
-    assert_response HTTPotion.head_direct(:non_pooled_connection, "http://httpbin.org/cookies/set?first=foo&second=bar"), fn(response) ->
+    assert_response HTTPotion.head("http://httpbin.org/cookies/set?first=foo&second=bar", [direct: :non_pooled_connection]), fn(response) ->
       assert_list response.headers[:"Set-Cookie"], ["first=foo; Path=/", "second=bar; Path=/"]
     end
   end
 
   test "ibrowse option" do
     ibrowse = [basic_auth: {'foo', 'bar'}]
-    assert_response HTTPotion.get_direct(:non_pooled_connection, "http://httpbin.org/basic-auth/foo/bar", [], [ ibrowse: ibrowse ])
+    assert_response HTTPotion.get("http://httpbin.org/basic-auth/foo/bar", [], [ ibrowse: ibrowse, direct: :non_pooled_connection ])
   end
 
   test "explicit http scheme" do
-    assert_response HTTPotion.head_direct(:non_pooled_connection, "http://httpbin.org/get")
+    assert_response HTTPotion.head("http://httpbin.org/get", [direct: :non_pooled_connection])
   end
 
   test "https scheme" do
-    assert_response HTTPotion.head_direct(:non_pooled_connection, "https://httpbin.org/get")
+    assert_response HTTPotion.head("https://httpbin.org/get", [direct: :non_pooled_connection])
   end
 
   test "char list URL" do
-    assert_response HTTPotion.head_direct(:non_pooled_connection, 'httpbin.org/get')
+    assert_response HTTPotion.head('httpbin.org/get', [direct: :non_pooled_connection])
   end
 
   test "exception" do
     assert_raise HTTPotion.HTTPError, "econnrefused", fn ->
-      HTTPotion.get "localhost:1"
+      HTTPotion.get "localhost:1", [direct: :non_pooled_connection]
     end
   end
 
@@ -89,14 +89,14 @@ defmodule DirectTest do
       end
     end
 
-    TestClient.head_direct(:non_pooled_connection, "httpbin.org/get")
+    TestClient.head("httpbin.org/get", [direct: :non_pooled_connection])
 
     assert_received :ok
   end
 
   test "asynchronous request" do
     ibrowse = [basic_auth: {'foo', 'bar'}]
-    %HTTPotion.AsyncResponse{ id: id } = HTTPotion.get_direct :non_pooled_connection, "httpbin.org/basic-auth/foo/bar", [], [stream_to: self, ibrowse: ibrowse]
+    %HTTPotion.AsyncResponse{ id: id } = HTTPotion.get "httpbin.org/basic-auth/foo/bar", [], [stream_to: self, ibrowse: ibrowse, direct: :non_pooled_connection]
 
     assert_receive %HTTPotion.AsyncHeaders{ id: ^id, status_code: 200, headers: _headers }, 1_000
     assert_receive %HTTPotion.AsyncChunk{ id: ^id, chunk: _chunk }, 1_000


### PR DESCRIPTION
I'm using HTTPotion with a service that has long polling as an option. Some of my requests would benefit from long polling but others need to be fast. Since both types of request are going to the same host ibrowse is sometimes queuing requests that should be fast behind long poll requests which isn't ideal. The send_req_direct functions in ibrowse let me get around this by sending my long poll requests to a separate pid so they don't go in the connection pool and get in the way of my other requests so I've wrapped that in this pull request.

I did some refactoring to avoid duplicating a bunch of code that would be shared between request and request_direct.

Also the reason spawn_worker_process and spawn_link_worker process don't just call their ibrowse equivalents is that it looks like ibrowse doesn't let you pass in your own options for the gen_server and I wanted to be able to provide a name for my worker process to be registered under when started by a supervisor so I can use that even if the worker process is restarted.

Let me know if you have any questions or think anything needs to change in order to merge this in.

Thanks!
