### PR TITLE
adding body for delete request

### DIFF
--- a/lib/httpotion.ex
+++ b/lib/httpotion.ex
@@ -144,13 +144,13 @@ defmodule HTTPotion.Base do
         end
       end
 
-      def get(url, headers \\ [], options \\ []),         do: request(:get, url, "", headers, options)
-      def put(url, body, headers \\ [], options \\ []),   do: request(:put, url, body, headers, options)
-      def head(url, headers \\ [], options \\ []),        do: request(:head, url, "", headers, options)
-      def post(url, body, headers \\ [], options \\ []),  do: request(:post, url, body, headers, options)
-      def patch(url, body, headers \\ [], options \\ []), do: request(:patch, url, body, headers, options)
-      def delete(url, headers \\ [], options \\ []),      do: request(:delete, url, "", headers, options)
-      def options(url, headers \\ [], options \\ []),     do: request(:options, url, "", headers, options)
+      def get(url, headers \\ [], options \\ []),                do: request(:get, url, "", headers, options)
+      def put(url, body, headers \\ [], options \\ []),          do: request(:put, url, body, headers, options)
+      def head(url, headers \\ [], options \\ []),               do: request(:head, url, "", headers, options)
+      def post(url, body, headers \\ [], options \\ []),         do: request(:post, url, body, headers, options)
+      def patch(url, body, headers \\ [], options \\ []),        do: request(:patch, url, body, headers, options)
+      def delete(url, body \\ "", headers \\ [], options \\ []), do: request(:delete, url, body, headers, options)
+      def options(url, headers \\ [], options \\ []),            do: request(:options, url, "", headers, options)
 
       defoverridable Module.definitions_in(__MODULE__)
     end

--- a/test/direct_test.exs
+++ b/test/direct_test.exs
@@ -39,7 +39,7 @@ defmodule DirectTest do
   end
 
   test "delete" do
-    assert_response HTTPotion.delete("httpbin.org/delete", [direct: :non_pooled_connection])
+    assert_response HTTPotion.delete("httpbin.org/delete", "test", [direct: :non_pooled_connection])
   end
 
   test "options" do


### PR DESCRIPTION
Hello,

It would be nice we had the option of sending a body with the DELETE method, for example when using it against elasticsearch in its [delete by query api](http://www.elasticsearch.org/guide/en/elasticsearch/reference/current/docs-delete-by-query.html).

The downside for this patch is that it breaks backward compatibility because of the change in the delete function signature. But since there are default values for the other arguments, it seems difficult to support both versions.

Thoughts?

Thanks in advance!