### PR TITLE
Edited README.md for replacing deprecated function

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ defmodule GitHub do
 
   def process_response_body(body) do
     json = :jsx.decode to_string(body)
-    json2 = Enum.map json, fn ({k, v}) -> { binary_to_atom(k), v } end
+    json2 = Enum.map json, fn ({k, v}) -> { String.to_atom(k), v } end
     :orddict.from_list json2
   end
 end


### PR DESCRIPTION
Replace deprecated (in v0.13.3) binary_to_atom/1 with String.to_atom/1