### PR TITLE
add convenient way of passing basic_auth options

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,9 @@ iex> response = HTTPotion.post "https://httpbin.org/post", [body: "hello=world",
 iex> response = HTTPotion.request :propfind, "http://httpbin.org/post", [body: "I have no idea what I'm doing"]
 %HTTPotion.Response{body: "...", headers: [Connection: "keep-alive", ...], status_code: 405}
 
+iex> response = HTTPotion.get "httpbin.org/basic-auth/foo/bar", [basic_auth: {"foo", "bar"}]
+%HTTPotion.Response{body: "...", headers: ["Access-Control-Allow-Credentials": "true", ...], status_code: 200}
+
 iex> HTTPotion.get "http://localhost:1"
 ** (HTTPotion.HTTPError) econnrefused
 ```

--- a/lib/httpotion.ex
+++ b/lib/httpotion.ex
@@ -96,6 +96,7 @@ defmodule HTTPotion.Base do
         * body - request body, binary string or char list
         * headers - HTTP headers, orddict (eg. ["Accept": "application/json"])
         * timeout - timeout in ms, integer
+        * basic_auth - basic auth credentials (eg. {"user", "password"})
         * stream_to - if you want to make an async request, the pid of the process
         * direct - if you want to use ibrowse's direct feature, the pid of
                    the worker spawned by spawn_worker_process or spawn_link_worker_process

--- a/lib/httpotion.ex
+++ b/lib/httpotion.ex
@@ -51,6 +51,11 @@ defmodule HTTPotion.Base do
           ib_options = Dict.put(ib_options, :stream_to, spawn(__MODULE__, :transformer, [stream_to]))
         end
 
+        if user_password = Dict.get(options, :basic_auth) do
+          {user, password} = user_password
+          ib_options = Dict.put(ib_options, :basic_auth, { to_char_list(user), to_char_list(password) })
+        end
+
         %{
           method:     method,
           url:        url |> to_string |> process_url |> to_char_list,

--- a/test/httpotion_test.exs
+++ b/test/httpotion_test.exs
@@ -50,7 +50,7 @@ defmodule HTTPotionTest do
   end
 
   test "basic_auth option" do
-    assert_response HTTPotion.get("http://httpbin.org/basic-auth/foo/bar", [ basic_auth: {'foo', 'bar'} ])
+    assert_response HTTPotion.get("http://httpbin.org/basic-auth/foo/bar", [ basic_auth: {"foo", "bar"} ])
   end
 
   test "ibrowse option" do

--- a/test/httpotion_test.exs
+++ b/test/httpotion_test.exs
@@ -49,6 +49,10 @@ defmodule HTTPotionTest do
     end
   end
 
+  test "basic_auth option" do
+    assert_response HTTPotion.get("http://httpbin.org/basic-auth/foo/bar", [ basic_auth: {'foo', 'bar'} ])
+  end
+
   test "ibrowse option" do
     ibrowse = [basic_auth: {'foo', 'bar'}]
     assert_response HTTPotion.get("http://httpbin.org/basic-auth/foo/bar", [ ibrowse: ibrowse ])


### PR DESCRIPTION
I was trying to access a basic auth protected resource and didn't find out how to pass user and password until I looked at the tests. 

I thought a little more convenient way would be nice.