### PR TITLE
Make error handling more robust

### DIFF
--- a/lib/httpotion.ex
+++ b/lib/httpotion.ex
@@ -123,6 +123,10 @@ defmodule HTTPotion.Base do
         request(method, url, options |> Dict.put(:direct, conn_pid))
       end
 
+      defp error_to_string(error) do
+        if is_atom(error) or String.valid?(error), do: to_string(error), else: inspect(error)
+      end
+
       def handle_response(response) do
         case response do
           { :ok, status_code, headers, body, _ } ->
@@ -140,11 +144,11 @@ defmodule HTTPotion.Base do
           { :ibrowse_req_id, id } ->
             %HTTPotion.AsyncResponse{ id: id }
           { :error, { :conn_failed, { :error, reason }}} ->
-            raise HTTPotion.HTTPError, message: to_string(reason)
+            raise HTTPotion.HTTPError, message: error_to_string(reason)
           { :error, :conn_failed } ->
             raise HTTPotion.HTTPError, message: "conn_failed"
           { :error, reason } ->
-            raise HTTPotion.HTTPError, message: to_string(reason)
+            raise HTTPotion.HTTPError, message: error_to_string(reason)
         end
       end
 


### PR DESCRIPTION
Some errors returned by iBrowse cause an error in Httpotion for example:

iex(1)> HTTPotion.get("httpa://news.bbc.co.uk")
** (Protocol.UndefinedError) protocol String.Chars not implemented for {:url_parsing_failed, {:error, :invalid_uri}}
       (elixir) lib/string/chars.ex:3: String.Chars.impl_for!/1
       (elixir) lib/string/chars.ex:17: String.Chars.to_string/1
    (httpotion) lib/httpotion.ex:195: HTTPotion.handle_response/1

The problem being an invalid uri has been passed.

This change preserves existing behaviour for strings and atoms - which is fine, but allows httpotion to handle other types of errors (e.g. nested tuples). With the change you get

iex(1)> HTTPotion.get("httpa://news.bbc.co.uk")
** (HTTPotion.HTTPError) {:url_parsing_failed, {:error, :invalid_uri}}
    (httpotion) lib/httpotion.ex:205: HTTPotion.handle_response/1


