### PR TITLE
Add `process_options` hook for HTTPotion.Base

### DIFF
--- a/lib/httpotion.ex
+++ b/lib/httpotion.ex
@@ -40,8 +40,11 @@ defmodule HTTPotion.Base do
         end) |> Enum.sort
       end
 
+      def process_options(options), do: options
+
       @spec process_arguments(atom, String.t, :dict.dict) :: :dict.dict
       def process_arguments(method, url, options) do
+        options    = process_options(options)
         body       = Dict.get(options, :body, "")
         headers    = Dict.get(options, :headers, [])
         timeout    = Dict.get(options, :timeout, 5000)

--- a/test/httpotion_test.exs
+++ b/test/httpotion_test.exs
@@ -87,15 +87,19 @@ defmodule HTTPotionTest do
       use HTTPotion.Base
 
       def process_url(url) do
-        send(self, :ok)
-
+        send(self, :processed_url)
         super(url)
+      end
+
+      def process_options(options) do
+        send(self, :processed_options)
+        super(options)
       end
     end
 
     TestClient.head("httpbin.org/get")
-
-    assert_received :ok
+    assert_received :processed_url
+    assert_received :processed_options
   end
 
   test "asynchronous request" do


### PR DESCRIPTION
This hook is useful for API clients that need to use basic authentication. Such clients can inject their `basic_auth` option into the options list, like so:

```elixir
defmodule Api do
  use HTTPotion.Base

  def process_options(options) do
    Dict.put(options, :basic_auth, { "user", "pass" })
  end
end
```