### PR TITLE
Fix incorrect typespecs

### DIFF
--- a/lib/httpotion.ex
+++ b/lib/httpotion.ex
@@ -42,7 +42,7 @@ defmodule HTTPotion.Base do
 
       def process_options(options), do: options
 
-      @spec process_arguments(atom, String.t, :dict.dict) :: :dict.dict
+      @spec process_arguments(atom, String.t, Dict.t) :: Dict.t
       def process_arguments(method, url, options) do
         options    = process_options(options)
         body       = Dict.get(options, :body, "")
@@ -106,7 +106,7 @@ defmodule HTTPotion.Base do
       Returns HTTPotion.Response or HTTPotion.AsyncResponse if successful.
       Raises  HTTPotion.HTTPError if failed.
       """
-      @spec request(atom, String.t, :dict.dict) :: HTTPotion.Response | HTTPotion.AsyncResponse
+      @spec request(atom, String.t, Dict.t) :: %HTTPotion.Response{} | %HTTPotion.AsyncResponse{}
       def request(method, url, options \\ []) do
         args = process_arguments(method, url, options)
         if conn_pid = Dict.get(options, :direct) do


### PR DESCRIPTION
I started using [Dialyzer][dialyzer] to analyze [one of my projects][ex_twilio] and I came across this typespec error:

```
httpotion.ex:208: Invalid type specification for function 'Elixir.HTTPotion':request/3. The success typing is (atom(),binary(),[any()] | #{}) -> #{}
```

HTTPotion apparently is using two outdated typespecs:

- `:dict.dict` should be `Dict.t`
- `HTTPotion.Response | HTTPotion.AsyncResponse` should be `%HTTPotion.Response{} | %HTTPotion.AsyncResponse{}`

[dialyzer]: http://www.erlang.org/doc/man/dialyzer.html
[ex_twilio]: https://github.com/danielberkompas/ex_twilio