### PR TITLE
Pass chunk errors without modification

### DIFF
--- a/lib/httpotion.ex
+++ b/lib/httpotion.ex
@@ -29,6 +29,7 @@ defmodule HTTPotion.Base do
       def process_response_body(body), do: IO.iodata_to_binary(body)
 
       def process_response_chunk(body = {:file, filename}), do: IO.iodata_to_binary(filename)
+      def process_response_chunk(chunk = {:error, error}), do: chunk
       def process_response_chunk(chunk), do: IO.iodata_to_binary(chunk)
 
       def process_response_headers(headers) do


### PR DESCRIPTION
Without this patch, httpotion is calling `IO.iodata_to_binary(chunk)` even when ibrowse sends an error.

I noticed that generally httpotion likes to raise exceptions on ibrowse errors. I tried this but haven't figured out how to rescue these exceptions in my application code (using the `stream_to: ...` API)

Therefore I submit this solution.