### PR TITLE
Update ibrowse version

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Add HTTPotion **and ibrowse** to your project's dependencies in `mix.exs`:
 ```elixir
   defp deps do
     [
-      {:ibrowse, github: "cmullaparthi/ibrowse", tag: "v4.1.1"},
+      {:ibrowse, github: "cmullaparthi/ibrowse", tag: "v4.1.2"},
       {:httpotion, "~> 2.1.0"}
     ]
   end

--- a/mix.exs
+++ b/mix.exs
@@ -21,7 +21,7 @@ defmodule HTTPotion.Mixfile do
   end
 
   defp deps do
-    [{:ibrowse, github: "cmullaparthi/ibrowse", tag: "v4.1.1"}]
+    [{:ibrowse, github: "cmullaparthi/ibrowse", tag: "v4.1.2"}]
   end
 
   defp package do

--- a/mix.lock
+++ b/mix.lock
@@ -1,1 +1,1 @@
-%{"ibrowse": {:git, "git://github.com/cmullaparthi/ibrowse.git", "d2e369ff42666c3574b8b7ec26f69027895c4d94", [tag: "v4.1.1"]}}
+%{"ibrowse": {:git, "git://github.com/cmullaparthi/ibrowse.git", "ea3305d21f37eced4fac290f64b068e56df7de80", [tag: "v4.1.2"]}}


### PR DESCRIPTION
ibrowser v4.1.1 or lower cannot work on Erlang R18 by using deprecated API.

See also
- https://github.com/cmullaparthi/ibrowse/issues/129