### PR TITLE
Add query string support.

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,21 @@ The `Response` is [a struct](http://elixir-lang.org/getting-started/structs.html
 
 *Note*: the API changed in 2.0.0, body and headers are options now!
 
+Available options and their default value:
+
+```elixir
+{
+  body: "",                # Request's body contents Ex.: "{json: \"string\"}"
+  headers: [],             # Request's headers. Ex.: ["Accepts" => "application/json"]
+  timeout: 5000,           # Timeout in milliseconds Ex: 5000
+  ibrowse: [],             # Ibrowse options
+  follow_redirects: false, # Specify wether redirects should or not be followed
+  stream_to: nil,          # Specify a process to stream the response to when performing async requests
+  basic_auth: nil,         # Basic auth credentials. Ex.: {"username", "password"}
+}
+
+```
+
 ### Metaprogramming magic
 
 You can extend `HTTPotion.Base` to make cool API clients or something (this example uses [jsx] for JSON):

--- a/lib/httpotion.ex
+++ b/lib/httpotion.ex
@@ -103,22 +103,15 @@ defmodule HTTPotion.Base do
           { :ibrowse_async_headers, id, status_code, headers } ->
             if(process_status_code(status_code) in [302, 304]) do
               location = process_response_headers(headers)[:Location]
-              response = request(method, normalize_location(location, url))
-
-              send(target, %HTTPotion.AsyncHeaders{
-                id: id,
-                status_code: response.status_code,
-                headers: response.headers
-              })
+              request(method, normalize_location(location, url), options)
             else
               send(target, %HTTPotion.AsyncHeaders{
                 id: id,
                 status_code: process_status_code(status_code),
                 headers: process_response_headers(headers)
               })
+              transformer(target, method, url, options)
             end
-
-            transformer(target, method, url, options)
           { :ibrowse_async_response, id, chunk } ->
             send(target, %HTTPotion.AsyncChunk{
               id: id,

--- a/lib/httpotion.ex
+++ b/lib/httpotion.ex
@@ -1,7 +1,7 @@
 defmodule HTTPotion.Base do
   @moduledoc """
   The base module of HTTPotion.
-  
+
   When used, it defines overridable functions, which allows you to make customized HTTP client modules (see the README).
   It is used by the `HTTPotion` module to provide the a basic general-purpose client.
   """
@@ -44,6 +44,10 @@ defmodule HTTPotion.Base do
       def process_response_chunk(chunk = {:error, error}), do: chunk
       def process_response_chunk(chunk), do: IO.iodata_to_binary(chunk)
 
+      def process_response_location(response) do
+        process_response_headers(elem(response, 2))[:Location]
+      end
+
       def process_response_headers(headers) do
         Enum.reduce(headers, [], fn { k, v }, acc ->
           key = k |> to_string |> String.to_atom
@@ -51,6 +55,15 @@ defmodule HTTPotion.Base do
 
           Dict.update(acc, key, value, &[value | List.wrap(&1)])
         end) |> Enum.sort
+      end
+
+      def is_redirect(response) do
+        status_code = process_status_code(elem(response, 1))
+        status_code > 300 && status_code < 400
+      end
+
+      def response_ok(response) do
+        elem(response, 0) == :ok
       end
 
       def process_options(options), do: options
@@ -62,6 +75,7 @@ defmodule HTTPotion.Base do
         headers    = Dict.get(options, :headers, [])
         timeout    = Dict.get(options, :timeout, 5000)
         ib_options = Dict.get(options, :ibrowse, [])
+        follow_redirects = Dict.get(options, :follow_redirects, false)
 
         if stream_to = Dict.get(options, :stream_to) do
           ib_options = Dict.put(ib_options, :stream_to, spawn(__MODULE__, :transformer, [stream_to]))
@@ -78,7 +92,8 @@ defmodule HTTPotion.Base do
           body:       body |> process_request_body,
           headers:    headers |> process_request_headers |> Enum.map(fn ({k, v}) -> { to_char_list(k), to_char_list(v) } end),
           timeout:    timeout,
-          ib_options: ib_options
+          ib_options: ib_options,
+          follow_redirects: follow_redirects
         }
       end
 
@@ -120,18 +135,32 @@ defmodule HTTPotion.Base do
       * `stream_to` - if you want to make an async request, the pid of the process
       * `direct` - if you want to use ibrowse's direct feature, the pid of
                   the worker spawned by `spawn_worker_process/2` or `spawn_link_worker_process/2`
+      * `follow_redirects` - if true and a response is a redirect, header[:Location] is taken for the next request
 
-      Returns `HTTPotion.Response` or `HTTPotion.AsyncResponse` if successful.  
+      Returns `HTTPotion.Response` or `HTTPotion.AsyncResponse` if successful.
       Raises  `HTTPotion.HTTPError` if failed.
       """
       @spec request(atom, String.t, Dict.t) :: %HTTPotion.Response{} | %HTTPotion.AsyncResponse{}
       def request(method, url, options \\ []) do
         args = process_arguments(method, url, options)
-        if conn_pid = Dict.get(options, :direct) do
+        response = if conn_pid = Dict.get(options, :direct) do
           :ibrowse.send_req_direct(conn_pid, args[:url], args[:headers], args[:method], args[:body], args[:ib_options], args[:timeout])
         else
           :ibrowse.send_req(args[:url], args[:headers], args[:method], args[:body], args[:ib_options], args[:timeout])
-        end |> handle_response
+        end
+
+        if response_ok(response) && is_redirect(response) && options[:follow_redirects] do
+          location = process_response_location(response)
+          next_url = if String.starts_with?(location, "http") do
+            location
+          else
+            Regex.named_captures(~r/(?<url>http:\/\/.*?)\//, url)["url"] <> location
+          end
+
+          request(method, next_url, options)
+        else
+          handle_response response
+        end
       end
 
       @doc "Deprecated form of `request`; body and headers are now options, see `request/3`."

--- a/lib/httpotion.ex
+++ b/lib/httpotion.ex
@@ -154,9 +154,8 @@ defmodule HTTPotion.Base do
           next_url = if String.starts_with?(location, "http") do
             location
           else
-            Regex.named_captures(~r/(?<url>http:\/\/.*?)\//, url)["url"] <> location
+            Regex.named_captures(~r/(?<url>https?:\/\/.*?)\//, url)["url"] <> location
           end
-
           request(method, next_url, options)
         else
           handle_response response

--- a/mix.lock
+++ b/mix.lock
@@ -1,3 +1,3 @@
 %{"earmark": {:hex, :earmark, "0.1.17"},
   "ex_doc": {:hex, :ex_doc, "0.9.0"},
-  "ibrowse": {:git, "git://github.com/cmullaparthi/ibrowse.git", "ea3305d21f37eced4fac290f64b068e56df7de80", [tag: "v4.1.2"]}}
+  "ibrowse": {:git, "https://github.com/cmullaparthi/ibrowse.git", "ea3305d21f37eced4fac290f64b068e56df7de80", [tag: "v4.1.2"]}}

--- a/test/direct_test.exs
+++ b/test/direct_test.exs
@@ -50,7 +50,8 @@ defmodule DirectTest do
   end
 
   test "headers" do
-    assert_response HTTPotion.head("http://httpbin.org/cookies/set?first=foo&second=bar", [direct: :non_pooled_connection]), fn(response) ->
+    options = [direct: :non_pooled_connection, query: %{first: "foo", second: "bar"}]
+    assert_response HTTPotion.head("http://httpbin.org/cookies/set", options), fn(response) ->
       assert_list response.headers[:"Set-Cookie"], ["first=foo; Path=/", "second=bar; Path=/"]
     end
   end

--- a/test/httpotion_test.exs
+++ b/test/httpotion_test.exs
@@ -76,6 +76,10 @@ defmodule HTTPotionTest do
     assert_response HTTPotion.head('httpbin.org/get')
   end
 
+  test "query string encoding" do
+    assert HTTPotion.process_url("http://example.com", [query: %{param: "value"}]) == "http://example.com?param=value"
+  end
+
   test "exception" do
     assert_raise HTTPotion.HTTPError, "econnrefused", fn ->
       HTTPotion.get("localhost:1")

--- a/test/httpotion_test.exs
+++ b/test/httpotion_test.exs
@@ -111,6 +111,15 @@ defmodule HTTPotionTest do
     assert_receive %HTTPotion.AsyncEnd{ id: ^id }, 1_000
   end
 
+  test "asynchronous follow redirect" do
+    ibrowse = [basic_auth: {'foo', 'bar'}]
+    %HTTPotion.AsyncResponse{ id: id } = HTTPotion.get "http://httpbin.org/absolute-redirect/1", [stream_to: self, ibrowse: ibrowse]
+
+    assert_receive %HTTPotion.AsyncHeaders{ id: ^id, status_code: 200, headers: _headers }, 1_000
+    assert_receive %HTTPotion.AsyncChunk{ id: ^id, chunk: _chunk }, 1_000
+    assert_receive %HTTPotion.AsyncEnd{ id: ^id }, 1_000
+  end
+
   test "follow relative redirect" do
     response = HTTPotion.get("http://httpbin.org/relative-redirect/1", [ follow_redirects: true ])
 

--- a/test/httpotion_test.exs
+++ b/test/httpotion_test.exs
@@ -111,6 +111,7 @@ defmodule HTTPotionTest do
     assert_receive %HTTPotion.AsyncEnd{ id: ^id }, 1_000
   end
 
+  @tag skip: true
   test "asynchronous follow redirect" do
     ibrowse = [basic_auth: {'foo', 'bar'}]
     %HTTPotion.AsyncResponse{ id: id } = HTTPotion.get "http://httpbin.org/absolute-redirect/1", [stream_to: self, ibrowse: ibrowse]

--- a/test/httpotion_test.exs
+++ b/test/httpotion_test.exs
@@ -111,14 +111,13 @@ defmodule HTTPotionTest do
     assert_receive %HTTPotion.AsyncEnd{ id: ^id }, 1_000
   end
 
-  @tag skip: true
   test "asynchronous follow redirect" do
     ibrowse = [basic_auth: {'foo', 'bar'}]
     %HTTPotion.AsyncResponse{ id: id } = HTTPotion.get "http://httpbin.org/absolute-redirect/1", [stream_to: self, ibrowse: ibrowse]
 
-    assert_receive %HTTPotion.AsyncHeaders{ id: ^id, status_code: 200, headers: _headers }, 1_000
-    assert_receive %HTTPotion.AsyncChunk{ id: ^id, chunk: _chunk }, 1_000
-    assert_receive %HTTPotion.AsyncEnd{ id: ^id }, 1_000
+    assert_receive %HTTPotion.AsyncHeaders{ status_code: 200, headers: _headers }, 1_000
+    assert_receive %HTTPotion.AsyncChunk{ chunk: _chunk }, 1_000
+    assert_receive %HTTPotion.AsyncEnd{ }, 1_000
   end
 
   test "follow relative redirect" do

--- a/test/httpotion_test.exs
+++ b/test/httpotion_test.exs
@@ -119,8 +119,24 @@ defmodule HTTPotionTest do
     assert response.headers[:Location] == nil
   end
 
+  test "follow relative https redirect" do
+    response = HTTPotion.get("https://httpbin.org/relative-redirect/1", [ follow_redirects: true ])
+
+    assert_response response
+    assert response.status_code == 200
+    assert response.headers[:Location] == nil
+  end
+
   test "follow absolute redirect" do
     response = HTTPotion.get("http://httpbin.org/absolute-redirect/1", [ follow_redirects: true ])
+
+    assert_response response
+    assert response.status_code == 200
+    assert response.headers[:Location] == nil
+  end
+
+  test "follow absolute https redirect" do
+    response = HTTPotion.get("https://httpbin.org/absolute-redirect/1", [ follow_redirects: true ])
 
     assert_response response
     assert response.status_code == 200

--- a/test/httpotion_test.exs
+++ b/test/httpotion_test.exs
@@ -111,6 +111,22 @@ defmodule HTTPotionTest do
     assert_receive %HTTPotion.AsyncEnd{ id: ^id }, 1_000
   end
 
+  test "follow relative redirect" do
+    response = HTTPotion.get("http://httpbin.org/relative-redirect/1", [ follow_redirects: true ])
+
+    assert_response response
+    assert response.status_code == 200
+    assert response.headers[:Location] == nil
+  end
+
+  test "follow absolute redirect" do
+    response = HTTPotion.get("http://httpbin.org/absolute-redirect/1", [ follow_redirects: true ])
+
+    assert_response response
+    assert response.status_code == 200
+    assert response.headers[:Location] == nil
+  end
+
   defp assert_response(response, function \\ nil) do
     assert HTTPotion.Response.success?(response, :extra)
     assert response.headers[:Connection] == "keep-alive"


### PR DESCRIPTION
This pull request adds the capability to specify query string parameters
in the options hash.

Ex.:

```elixir
iex> HTTPotion.get("www.example.com", query: %{page: 2}) # Yields a request with "www.example.com?page=2" as the url
```