### PR TITLE
Specify default timeout in application config

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -1,3 +1,5 @@
 use Mix.Config
 
 config :ex_doc, :markdown_processor, ExDoc.Markdown.Pandoc
+
+config :httpotion, :default_timeout, 5000

--- a/lib/httpotion.ex
+++ b/lib/httpotion.ex
@@ -94,7 +94,7 @@ defmodule HTTPotion.Base do
 
         body       = Dict.get(options, :body, "")
         headers    = Dict.get(options, :headers, [])
-        timeout    = Dict.get(options, :timeout, 5000)
+        timeout    = Dict.get(options, :timeout, Application.get_env(:httpotion, :default_timeout))
         ib_options = Dict.get(options, :ibrowse, [])
         follow_redirects = Dict.get(options, :follow_redirects, false)
 


### PR DESCRIPTION
This allows users to override the default for an entire application.