### PR TITLE
Remove warning

### DIFF
--- a/lib/httpotion.ex
+++ b/lib/httpotion.ex
@@ -289,10 +289,6 @@ defmodule HTTPotion do
       {val, %Headers{hdrs: updated}}
     end
   end
-  defimpl Access, for: Headers do
-    def fetch(headers, key), do: Headers.fetch(headers, key)
-    def get_and_update(headers, key, acc), do: Headers.get_and_update(headers, key, acc)
-  end
 
   defmodule AsyncResponse do
     defstruct id: nil

--- a/mix.exs
+++ b/mix.exs
@@ -6,7 +6,7 @@ defmodule HTTPotion.Mixfile do
       name: "httpotion",
       source_url: "https://github.com/myfreeweb/httpotion",
       version: "2.2.2",
-      elixir:  "~> 1.0",
+      elixir:  "~> 1.2",
       docs: [ extras: ["README.md", "CODE_OF_CONDUCT.md"] ],
       description: description,
       deps: deps,


### PR DESCRIPTION
Bump elixir version and remove Access protocol to remove

`lib/httpotion.ex:292: warning: implementation of the Access protocol is deprecated. For customization of the dict[key] syntax, please implement the Dict behaviour instead`

Reference: https://github.com/elixir-lang/elixir/issues/2973