### PR TITLE
Upgrade to ex_doc 0.12

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -25,7 +25,7 @@ defmodule HTTPotion.Mixfile do
 
   defp deps do
     [ {:ibrowse, "~> 4.2"},
-      {:ex_doc, "~> 0.11", only: [:dev, :test, :docs]} ]
+      {:ex_doc, "~> 0.12", only: [:dev, :test, :docs]} ]
   end
 
   defp package do

--- a/mix.lock
+++ b/mix.lock
@@ -1,2 +1,3 @@
-%{"ex_doc": {:hex, :ex_doc, "0.11.5", "0dc51cb84f8312162a2313d6c71573a9afa332333d8a332bb12540861b9834db", [:mix], [{:earmark, "~> 0.1.17 or ~> 0.2", [hex: :earmark, optional: true]}]},
+%{"earmark": {:hex, :earmark, "0.2.1", "ba6d26ceb16106d069b289df66751734802777a3cbb6787026dd800ffeb850f3", [:mix], []},
+  "ex_doc": {:hex, :ex_doc, "0.12.0", "b774aabfede4af31c0301aece12371cbd25995a21bb3d71d66f5c2fe074c603f", [:mix], [{:earmark, "~> 0.2", [hex: :earmark, optional: false]}]},
   "ibrowse": {:hex, :ibrowse, "4.2.2", "b32b5bafcc77b7277eff030ed32e1acc3f610c64e9f6aea19822abcadf681b4b", [:rebar3], []}}


### PR DESCRIPTION
When run from master, you get some warnings based on changes to elixir 1.3

```
16:27 /src/httpotion (master)$ mix test
==> ex_doc
Compiling 12 files (.ex)
warning: function Cmark.to_html/1 is undefined (module Cmark is not available)
  lib/ex_doc/markdown/cmark.ex:18

warning: function Markdown.to_html/2 is undefined (module Markdown is not available)
  lib/ex_doc/markdown/hoedown.ex:29

Generated ex_doc app
==> httpotion
Compiling 1 file (.ex)
Generated httpotion app
............................................

Finished in 3.9 seconds
44 tests, 0 failures

Randomized with seed 66162
```

With the upgrade to 0.12, these go away

```
16:30 /src/httpotion (upgrade-elixir-1.3)$ mix test
............................................

Finished in 4.3 seconds
44 tests, 0 failures

Randomized with seed 952333
```