### PR TITLE
Fix #100: Follow redirects when extended

### DIFF
--- a/lib/httpotion.ex
+++ b/lib/httpotion.ex
@@ -175,7 +175,7 @@ defmodule HTTPotion.Base do
           :ibrowse.send_req(args[:url], args[:headers], args[:method], args[:body], args[:ib_options], args[:timeout])
         end
 
-        if response_ok(response) && is_redirect(response) && options[:follow_redirects] do
+        if response_ok(response) && is_redirect(response) && args[:follow_redirects] do
           location = process_response_location(response)
           next_url = normalize_location(location, url)
           request(method, next_url, options)

--- a/test/httpotion_test.exs
+++ b/test/httpotion_test.exs
@@ -171,6 +171,19 @@ defmodule HTTPotionTest do
     assert response.headers[:Location] == nil
   end
 
+  test "follow relative redirect when specified in options" do
+    defmodule ExampleWithRedirect do
+      use HTTPotion.Base
+      defp process_options(options), do: Keyword.put(options, :follow_redirects, true)
+    end
+
+    response = ExampleWithRedirect.get("http://httpbin.org/relative-redirect/1")
+
+    assert_response response
+    assert response.status_code == 200
+    assert response.headers[:Location] == nil
+  end
+
   defp assert_response(response, function \\ nil) do
     assert HTTPotion.Response.success?(response, :extra)
     assert response.headers[:Connection] == "keep-alive"


### PR DESCRIPTION
API clients that are built by extending `HTTPotion.Base`
can use the `process_options` hook to ensure that all
redirects will be followed automatically. A typo in that
module caused `follow_redirects` to be ignored.

This adds a test to specifically cover the behavior of
an API client using `process_options` to inject a `true`
value for `follow_redirects`, and fixes the typo.