### PR TITLE
Remove deprecation warnings related to `self()` and `fixture_path()`

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,8 @@ sudo: false
 language: elixir
 elixir:
   - 1.2.3
+  - 1.3.1
+  - 1.4.1
 otp_release:
   - 18.2.1
 

--- a/test/direct_test.exs
+++ b/test/direct_test.exs
@@ -85,7 +85,7 @@ defmodule DirectTest do
       use HTTPotion.Base
 
       def process_url(url) do
-        send(self, :ok)
+        send(self(), :ok)
 
         super(url)
       end
@@ -98,7 +98,7 @@ defmodule DirectTest do
 
   test "asynchronous request" do
     ibrowse = [basic_auth: {'foo', 'bar'}]
-    %HTTPotion.AsyncResponse{ id: id } = HTTPotion.get "httpbin.org/basic-auth/foo/bar", [stream_to: self, ibrowse: ibrowse, direct: :non_pooled_connection]
+    %HTTPotion.AsyncResponse{ id: id } = HTTPotion.get "httpbin.org/basic-auth/foo/bar", [stream_to: self(), ibrowse: ibrowse, direct: :non_pooled_connection]
 
     assert_receive %HTTPotion.AsyncHeaders{ id: ^id, status_code: 200, headers: _headers }, 1_000
     assert_receive %HTTPotion.AsyncChunk{ id: ^id, chunk: _chunk }, 1_000

--- a/test/httpotion_test.exs
+++ b/test/httpotion_test.exs
@@ -106,12 +106,12 @@ defmodule HTTPotionTest do
       use HTTPotion.Base
 
       def process_url(url) do
-        send(self, :processed_url)
+        send(self(), :processed_url)
         super(url)
       end
 
       def process_options(options) do
-        send(self, :processed_options)
+        send(self(), :processed_options)
         super(options)
       end
     end
@@ -123,7 +123,7 @@ defmodule HTTPotionTest do
 
   test "asynchronous request" do
     ibrowse = [basic_auth: {'foo', 'bar'}]
-    %HTTPotion.AsyncResponse{ id: id } = HTTPotion.get "httpbin.org/basic-auth/foo/bar", [stream_to: self, ibrowse: ibrowse]
+    %HTTPotion.AsyncResponse{ id: id } = HTTPotion.get "httpbin.org/basic-auth/foo/bar", [stream_to: self(), ibrowse: ibrowse]
 
     assert_receive %HTTPotion.AsyncHeaders{ id: ^id, status_code: 200, headers: _headers }, 1_000
     assert_receive %HTTPotion.AsyncChunk{ id: ^id, chunk: _chunk }, 1_000
@@ -132,7 +132,7 @@ defmodule HTTPotionTest do
 
   test "asynchronous follow redirect" do
     ibrowse = [basic_auth: {'foo', 'bar'}]
-    %HTTPotion.AsyncResponse{ id: _ } = HTTPotion.get "http://httpbin.org/absolute-redirect/1", [stream_to: self, ibrowse: ibrowse]
+    %HTTPotion.AsyncResponse{ id: _ } = HTTPotion.get "http://httpbin.org/absolute-redirect/1", [stream_to: self(), ibrowse: ibrowse]
 
     assert_receive %HTTPotion.AsyncHeaders{ status_code: 200, headers: _headers }, 1_000
     assert_receive %HTTPotion.AsyncChunk{ chunk: _chunk }, 1_000

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -6,6 +6,6 @@ defmodule PathHelpers do
   end
 
   def fixture_path(file_path) do
-    Path.join fixture_path, file_path
+    Path.join fixture_path(), file_path
   end
 end


### PR DESCRIPTION
Fixes warnings mentioned in #106 

Also adds newer versions of Elixir to Travis configuration.