### PR TITLE
Pass headers to process response* functions

### DIFF
--- a/lib/httpotion.ex
+++ b/lib/httpotion.ex
@@ -60,6 +60,8 @@ defmodule HTTPotion.Base do
       def process_response_body(body = {:file, filename}), do: IO.iodata_to_binary(filename)
       def process_response_body(body), do: IO.iodata_to_binary(body)
 
+      def process_response_body(_headers, body), do: process_response_body(body)
+
       def process_response_chunk(body = {:file, filename}), do: IO.iodata_to_binary(filename)
       def process_response_chunk(chunk = {:error, error}), do: chunk
       def process_response_chunk(raw) when is_tuple(raw), do: raw
@@ -248,16 +250,18 @@ defmodule HTTPotion.Base do
       def handle_response(response) do
         case response do
           { :ok, status_code, headers, body, _ } ->
+            processed_headers = process_response_headers(headers)
             %HTTPotion.Response{
               status_code: process_status_code(status_code),
-              headers: process_response_headers(headers),
-              body: process_response_body(body)
+              headers: processed_headers,
+              body: process_response_body(processed_headers, body)
             }
           { :ok, status_code, headers, body } ->
+            processed_headers = process_response_headers(headers)
             %HTTPotion.Response{
               status_code: process_status_code(status_code),
-              headers: process_response_headers(headers),
-              body: process_response_body(body)
+              headers: processed_headers,
+              body: process_response_body(processed_headers, body)
             }
           { :ibrowse_req_id, id } ->
             %HTTPotion.AsyncResponse{ id: id }

--- a/test/httpotion_test.exs
+++ b/test/httpotion_test.exs
@@ -114,11 +114,17 @@ defmodule HTTPotionTest do
         send(self(), :processed_options)
         super(options)
       end
+
+      def process_response_body(headers, body) do
+        send(self(), :processed_response_body)
+        super(headers, body)
+      end
     end
 
     TestClient.head("httpbin.org/get")
     assert_received :processed_url
     assert_received :processed_options
+    assert_received :processed_response_body
   end
 
   test "asynchronous request" do


### PR DESCRIPTION
The `Content-Type` response header can be crucial for properly decoding the response. This PR creates two arity variants of `process_response_body` and `process_response_chunk` for passing in the response headers, with default implementations falling back to the standard behavior by way of the one arity versions.