### PR TITLE
Fix ibrowse version to 4.0.0

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -29,7 +29,7 @@ defmodule HTTPotion.Mixfile do
   end
 
   defp deps do
-    [ {:ibrowse, "~> 4.4"},
+    [ {:ibrowse, "== 4.4.0"},
       {:ex_doc, "~> 0.18", only: [:dev, :test, :docs]} ]
   end
 


### PR DESCRIPTION
Fixes myfreeweb/httpotion#124

It seems ibrowse 4.0.1 has the problem.
So I fix ibrowse version to 4.0.0 in `mix.exs`.

This will remove after bugfix.