### PR TITLE
Add process_request_headers/3 to pass options

### DIFF
--- a/lib/httpotion.ex
+++ b/lib/httpotion.ex
@@ -57,6 +57,8 @@ defmodule HTTPotion.Base do
 
       def process_request_headers(headers, _body), do: process_request_headers(headers)
 
+      def process_request_headers(headers, _body, _options), do: process_request_headers(headers)
+
       def process_status_code(status_code), do: elem(:string.to_integer(status_code), 0)
 
       def process_response_body(body = {:file, filename}), do: IO.iodata_to_binary(filename)
@@ -148,7 +150,7 @@ defmodule HTTPotion.Base do
         headers    = Application.get_env(:httpotion, :default_headers, [])
                      |> Keyword.merge(Keyword.get(options, :headers, [])
                        |> Enum.map(fn ({k, v}) -> { (if is_atom(k), do: k, else: String.to_atom(to_string(k))), to_string(v) } end))
-                     |> process_request_headers(body)
+                     |> process_request_headers(body, options)
         timeout    = Keyword.get(options, :timeout, Application.get_env(:httpotion, :default_timeout, 5000))
         ib_options = Application.get_env(:httpotion, :default_ibrowse, [])
                      |> Keyword.merge(Keyword.get(options, :ibrowse, []))

--- a/lib/httpotion.ex
+++ b/lib/httpotion.ex
@@ -57,7 +57,7 @@ defmodule HTTPotion.Base do
 
       def process_request_headers(headers, _body), do: process_request_headers(headers)
 
-      def process_request_headers(headers, _body, _options), do: process_request_headers(headers)
+      def process_request_headers(headers, body, _options), do: process_request_headers(headers, body)
 
       def process_status_code(status_code), do: elem(:string.to_integer(status_code), 0)
 


### PR DESCRIPTION
This change passes provided options from process_arguments/3 to
process_request_headers. This enables the user to inject custom
headers based on options. The change is backward compatible.

Fixes #129 